### PR TITLE
Switch base image to alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3.9
-COPY ./requirements.txt /requirements.txt
-RUN pip install -r /requirements.txt
-COPY ./app /app
-WORKDIR /app
+FROM python:3.10-alpine3.17
+WORKDIR /code
+COPY ./requirements.txt /code/requirements.txt
+RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
+COPY ./app /code
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "80", "--workers", "1"]


### PR DESCRIPTION
Switching base image to alpine to resolve vulnerabilities found by [container registry scanner](https://console.cloud.google.com/gcr/images/mystical-option-206009/global/qap2?project=mystical-option-206009)